### PR TITLE
Customize apt repository (useful for Ubuntu 17.04)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 # zabbix version
 zabbix_common_config_minor_version: '3.2'
 zabbix_common_environment: {}
+zabbix_common_apt_repository: "deb http://repo.zabbix.com/zabbix/{{ zabbix_common_config_minor_version }}/{{ ansible_distribution|lower }} {{ ansible_lsb.codename }} main contrib non-free"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,5 +1,5 @@
 ---
-- name: ensure pycurl is installed 
+- name: ensure pycurl is installed
   apt: name=python-pycurl state=installed
   environment: '{{ zabbix_common_environment }}'
 
@@ -8,7 +8,7 @@
   environment: '{{ zabbix_common_environment }}'
 
 - name: add zabbix.com repo
-  apt_repository: repo='deb http://repo.zabbix.com/zabbix/{{ zabbix_common_config_minor_version }}/{{ ansible_distribution|lower }} {{ ansible_lsb.codename }} main contrib non-free' state=present
+  apt_repository: repo='{{ zabbix_common_apt_repository }}' state=present
   register: repo
   environment: '{{ zabbix_common_environment }}'
 


### PR DESCRIPTION
Now we can define:

```yml
zabbix_common_apt_repository: "deb http://repo.zabbix.com/zabbix/{{ zabbix_common_config_minor_version }}/{{ ansible_distribution|lower }} xenial main contrib non-free"
```

for Ubuntu 17.04